### PR TITLE
Additional edits to improve readability and removed the bit about PIL

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -23,11 +23,11 @@ To speedup forge, an entropy generator such as
 Installation
 ----------
 
-First Tomb must be installed. Please refer to the
+First, Tomb must be installed. Please refer to the
 [Tomb documentation](https://github.com/dyne/Tomb/blob/master/INSTALL.md)
 to get Tomb installed on your system.
 
-Second tomber must be installed. Tomber can be installed from
+Second, tomber must be installed. Tomber can be installed from
 [PyPi](https://pypi.python.org/pypi) using
 [pip](https://pypi.python.org/pypi/pip). Enter the following command
 into terminal:


### PR DESCRIPTION
Apart from making minor edits on phrases, additional links were
provided to help the end user find resourced relating to this project.
Also removed line dealing with PIL. PIL is no long used in tomber.
Informing the reader that PIL is no longer used is no longer required.
